### PR TITLE
Fix: Typescript for PolygonCoords

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 import { BufferGeometry } from 'three';
 
-type PolygonCoords = number[][];
+type PolygonCoords = number[][][];
 
 type Parameters = {
   polygonGeoJson: PolygonCoords,


### PR DESCRIPTION
Based on the code and on @types/geojson.
A position is [number[]](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/geojson/index.d.ts#L41) 
A polygon is [position[][]](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/geojson/index.d.ts#L124)

which is why in your own [example you do](https://github.com/vasturiano/three-conic-polygon-geometry/blob/master/example/countries-gdp-per-capita/index.html#L25) 
```
const polygons = geometry.type === 'Polygon' ? [geometry.coordinates] : geometry.coordinates;
```
